### PR TITLE
Remove RegisterCommand trait properties

### DIFF
--- a/Application/RegisterCommandTrait.php
+++ b/Application/RegisterCommandTrait.php
@@ -7,16 +7,6 @@ use Ivoz\Core\Domain\Service\DomainEventPublisher;
 
 trait RegisterCommandTrait
 {
-    /**
-     * @var DomainEventPublisher
-     */
-    private $eventPublisher;
-
-    /**
-     * @var RequestId
-     */
-    private $requestId;
-
     private function registerCommand(string $service, string $method, $aguments = [], $agent = [])
     {
         $event = new CommandWasExecuted(


### PR DESCRIPTION
Remove RegisterCommand trait properties and create them as private constructor atributes in all workers and scheduler controllers.