### PR TITLE
Return topmost class instance in Sentinel fromConfigArray

### DIFF
--- a/Infrastructure/Domain/Service/Lifecycle/CommandPersister.php
+++ b/Infrastructure/Domain/Service/Lifecycle/CommandPersister.php
@@ -4,6 +4,7 @@ namespace Ivoz\Core\Infrastructure\Domain\Service\Lifecycle;
 
 use Ivoz\Core\Application\Event\CommandWasExecuted;
 use Ivoz\Core\Application\Service\CommandEventSubscriber;
+use Ivoz\Core\Domain\Event\EntityEventInterface;
 use Ivoz\Core\Domain\Service\EntityEventSubscriber;
 use Ivoz\Core\Domain\Service\EntityPersisterInterface;
 use Ivoz\Core\Domain\Model\Changelog\Changelog;
@@ -27,6 +28,7 @@ class CommandPersister
      */
     public function persistEvents()
     {
+        /** @var EntityEventInterface[] $entityEvents */
         $entityEvents = $this
             ->entityEventSubscriber
             ->getEvents();

--- a/Infrastructure/Persistence/Redis/Sentinel.php
+++ b/Infrastructure/Persistence/Redis/Sentinel.php
@@ -44,7 +44,7 @@ class Sentinel
     ) {
         $sentinelConfig = new SentinelConf($config);
 
-        return new self(
+        return new static(
             $sentinelConfig->get(),
             $logger
         );


### PR DESCRIPTION
This was removed in c0668405732da677993871780ff1aa8a47893add fixing phpstan errors
This must return static class for ivozprovider-realtime services