### PR TITLE
error prevention on non required uploadable files

### DIFF
--- a/Domain/Model/DtoNormalizer.php
+++ b/Domain/Model/DtoNormalizer.php
@@ -113,7 +113,12 @@ trait DtoNormalizer
         foreach ($contextProperties as $key => $value) {
             if (is_array($value)) {
                 foreach ($value as $property) {
-                    if (!isset($data[$key]) || !is_string($property) || !array_key_exists($property, $data[$key])) {
+                    if (
+                        !isset($data[$key])
+                        || !is_string($property)
+                        || !is_array($data[$key])
+                        || !array_key_exists($property, $data[$key])
+                    ) {
                         continue;
                     }
 


### PR DESCRIPTION
Avoid `array_key_exists(): Argument #2 ($array) must be of type array` error