### PR TITLE
Add embbeded file feature to emails

### DIFF
--- a/Domain/Model/Mailer/Embedded.php
+++ b/Domain/Model/Mailer/Embedded.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Ivoz\Core\Domain\Model\Mailer;
+
+use Ivoz\Core\Domain\Assert\Assertion;
+
+class Embedded
+{
+    public const TYPE_FILEPATH = 'file';
+    public const TYPE_CONTENT = 'content';
+
+    public const ALLOWED_TYPES = [
+        self::TYPE_FILEPATH,
+        self::TYPE_CONTENT,
+    ];
+
+    private string $type;
+
+    public function __construct(
+        private string  $filePath,
+        private ?string $name = null,
+        private ?string $mimetype = null,
+        string          $type = self::TYPE_FILEPATH
+    ) {
+        Assertion::choice(
+            $type,
+            self::ALLOWED_TYPES,
+            'type "%s" is not an element of the valid values: %s'
+        );
+
+        $this->type = $type;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function getFile(): string
+    {
+        return $this->filePath;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function getMimetype(): ?string
+    {
+        return $this->mimetype;
+    }
+
+
+}

--- a/Domain/Model/Mailer/Message.php
+++ b/Domain/Model/Mailer/Message.php
@@ -43,6 +43,11 @@ class Message
     protected $attachments = [];
 
     /**
+     * @var Embedded[]
+     */
+    protected $embedded = [];
+
+    /**
      * @internal
      */
     public function toEmail(): Email
@@ -85,6 +90,26 @@ class Message
                     $stream,
                     $attachment->getFilename(),
                     $attachment->getMimetype(),
+                );
+            }
+        }
+
+        foreach ($this->embedded as $embedded) {
+            if ($embedded->getType() === Attachment::TYPE_FILEPATH) {
+                $message->embed(
+                    $embedded->getFile(),
+                    $embedded->getName(),
+                    $embedded->getMimetype(),
+                );
+            } else {
+                $stream = fopen('php://memory', 'rw+');
+                fwrite($stream, $embedded->getFile());
+                rewind($stream);
+
+                $message->embed(
+                    $stream,
+                    $embedded->getName(),
+                    $embedded->getMimetype(),
                 );
             }
         }
@@ -173,6 +198,31 @@ class Message
             $filename,
             $mimetype,
             $type
+        );
+
+        return $this;
+    }
+
+    public function setEmbedded($file, $name, $mimetype, $type = Embedded::TYPE_FILEPATH): Message
+    {
+        $this->embedded = [];
+        $this->addEmbedded(
+            $file,
+            $name,
+            $mimetype,
+            $type,
+        );
+
+        return $this;
+    }
+
+    public function addEmbedded($file, $name, $mimetype,  $type = Embedded::TYPE_FILEPATH): Message
+    {
+        $this->embedded[] = new Embedded(
+            $file,
+            $name,
+            $mimetype,
+            $type,
         );
 
         return $this;


### PR DESCRIPTION
Added to Message new methods for embedding files into emails in a way that they can be referenced with "cid:file-id" syntax.